### PR TITLE
update packaging

### DIFF
--- a/README
+++ b/README
@@ -42,7 +42,7 @@ samtools http://samtools.sourceforge.net/
 Cufflinks (Spanky uses the gtf_to_sam utility to create a sam representation of a gtf reference) http://cufflinks.cbcb.umd.edu
 
 Required for splicing analysis:
-AStalavista (or a precomputed splicing event file) http://genome.crg.es/astalavista/
+AStalavista (or a precomputed splicing event file) http://sammeth.net/confluence/display/ASTA/Home
 
 Installation
 ---------------

--- a/bin/junccomp
+++ b/bin/junccomp
@@ -16,7 +16,7 @@ import operator
 from fisher import pvalue
 # Uses brent pedersen's model from pypi
 
-from scikits.statsmodels.sandbox.stats.multicomp import fdrcorrection0
+from statsmodels.sandbox.stats.multicomp import fdrcorrection0
 # BH correction is from http://statsmodels.sourceforge.net/devel/install.html
 
 # Custom modules to import:

--- a/bin/splicecomp
+++ b/bin/splicecomp
@@ -15,7 +15,7 @@ import operator
 from fisher import pvalue
 # Uses brent pedersen's model from pypi
 
-from scikits.statsmodels.sandbox.stats.multicomp import fdrcorrection0
+from statsmodels.sandbox.stats.multicomp import fdrcorrection0
 # BH correction is from http://statsmodels.sourceforge.net/devel/install.html
 
 # Custom modules to import:

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,5 @@ setup(
         	"scikits.statsmodels >= 0.3.1",
         	"biopython >= 1.50",
         	"pyfasta >= 0.4.4",
-        	"argparse >= 1.2.1",
          	"pysam >= 0.5"]
     )

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         install_requires=[
         	"fisher >= 0.1.4",
          	"scipy >= 0.1.10",
-        	"scikits.statsmodels >= 0.3.1",
+        	"statsmodels >= 0.3.1",
         	"biopython >= 1.50",
         	"pyfasta >= 0.4.4",
          	"pysam >= 0.5"]


### PR DESCRIPTION
This PR updates the packaging so that it can be build as a [bioconda](https://bioconda.github.io/) recipe
- convert scikit.statsmodels to statsmodels and update scripts to reflect changes (fixes #3)
- update astalavista URL
- remove argparse dependency (only relevant to py2.6 which hopefully is not being used much any more!)