### PR TITLE
Support rpk and cov in float

### DIFF
--- a/bin/spankisim_transcripts
+++ b/bin/spankisim_transcripts
@@ -1381,11 +1381,11 @@ def main():
 		elif txtab:
 		 	if 'rpk' in txtab[mytx].keys():
 		 		abundance_metric = "RPK"
-		 		abundance_value =  int(txtab[mytx]['rpk'])
+		 		abundance_value = float(txtab[mytx]['rpk'])
 		 		numreads = int(abundance_value * len(myseq_spliced)/1000)
 		 	elif 'cov' in txtab[mytx].keys():
 		 		abundance_metric = "Coverage"
- 				abundance_value = int(txtab[mytx]['cov'])
+ 				abundance_value = float(txtab[mytx]['cov'])
 		 		covtimeslength = abundance_value * len(myseq_spliced)
 				numreads = int(covtimeslength / mybp)
 			else:

--- a/extra/spanki_anno.py
+++ b/extra/spanki_anno.py
@@ -14,16 +14,15 @@ if __name__ == "__main__":
         help="The reference file in fasta format.")
 
     (options, args) = parser.parse_args()
-    fid = open(options.ref_file, 'r')
-    fasta = fid.readlines()
-    fid.close()
-    
+
     fasta_out = ".".join(options.ref_file.split(".")[:-1])
     fid = open(fasta_out + ".spanki.fa", "w")
 
-    for i in range(len(fasta)):
-        if fasta[i][0] != ">":
-            fid.writelines(fasta[i])
-        else:
-            fid.writelines(fasta[i].split()[0] + "\n")
+    with open(options.ref_file, 'r') as infile:
+        for line in infile:
+            if line.startswith(">"):
+                fid.writelines(line.rstrip().split()[0] + "\n")
+            else:
+                fid.writelines(line)
     fid.close()
+    

--- a/extra/spanki_anno.py
+++ b/extra/spanki_anno.py
@@ -1,0 +1,29 @@
+
+# The fasta file downloaded from GENCODE is not compatible with Spanki,
+# because the pyfasta package used in Spanki require ``>chr1`` rather than 
+# ``>chr1 extra information``. Thus, the fasta file needs a bit change, which 
+# can be done with this program.
+
+
+from optparse import OptionParser
+
+if __name__ == "__main__":
+    parser = OptionParser()
+
+    parser.add_option("--ref_file", "-f", dest="ref_file", default=None,
+        help="The reference file in fasta format.")
+
+    (options, args) = parser.parse_args()
+    fid = open(options.ref_file, 'r')
+    fasta = fid.readlines()
+    fid.close()
+    
+    fasta_out = ".".join(options.ref_file.split(".")[:-1])
+    fid = open(fasta_out + ".spanki.fa", "w")
+
+    for i in range(len(fasta)):
+        if fasta[i][0] != ">":
+            fid.writelines(fasta[i])
+        else:
+            fid.writelines(fasta[i].split()[0] + "\n")
+    fid.close()

--- a/spanki/spanki_utils.py
+++ b/spanki/spanki_utils.py
@@ -33,7 +33,7 @@ def gtf_to_attributes_dict(infn):
 				# This will cause a parsing error here.
 				# Note I now split on 'semicolon + space" - be on the lookout for exceptions
 				# such as gene names with spaces
-				del attributes[-1]
+				# del attributes[-1] #Turn off 
 				attributes = [x.strip() for x in attributes]
 				for attribute in attributes:
 					attr = attribute.strip().split(" ") # Split each item in attibutes line by space


### PR DESCRIPTION
In this pull request, it will support rpk or cov in float format, rather than only int format; it will also keep the attributes information. 

